### PR TITLE
Adding Steve to Notebook Council

### DIFF
--- a/docs/team/contributors.yaml
+++ b/docs/team/contributors.yaml
@@ -43,7 +43,13 @@
   affiliation: Apple
   team: active
   last-check-in: 2022-01
-  
+
+- name: Steve Silvester
+  handle: "@blink1073"
+  affiliation: MongoDB
+  team: active
+  last-check-in: 2022-03
+
 - name: Jeremy Tuloup
   handle: "@jtpio"
   affiliation: Quantstack


### PR DESCRIPTION
As per the process for [Bootstrapping Decision-Making Bodies](https://jupyter.org/governance/bootstrapping_decision_making.html), Steering Council members can be part of the subproject councils.

@blink1073  requested to be added to the Jupyter Notebook Council.